### PR TITLE
Use PRIu32 macro to silence -Wformat warnings with gcc 7.3

### DIFF
--- a/core_main.c
+++ b/core_main.c
@@ -284,8 +284,8 @@ MAIN_RETURN_TYPE main(int argc, char *argv[]) {
 	}
 	total_errors+=check_data_types();
 	/* and report results */
-	ee_printf("CoreMark Size    : %lu\n",(ee_u32)results[0].size);
-	ee_printf("Total ticks      : %lu\n",(ee_u32)total_time);
+	ee_printf("CoreMark Size    : %" PRIu32 "\n",(ee_u32)results[0].size);
+	ee_printf("Total ticks      : %" PRIu32 "\n",(ee_u32)total_time);
 #if HAS_FLOAT
 	ee_printf("Total time (secs): %f\n",time_in_secs(total_time));
 	if (time_in_secs(total_time) > 0)
@@ -300,7 +300,7 @@ MAIN_RETURN_TYPE main(int argc, char *argv[]) {
 		total_errors++;
 	}
 
-	ee_printf("Iterations       : %lu\n",(ee_u32)default_num_contexts*results[0].iterations);
+	ee_printf("Iterations       : %" PRIu32 "\n",(ee_u32)default_num_contexts*results[0].iterations);
 	ee_printf("Compiler version : %s\n",COMPILER_VERSION);
 	ee_printf("Compiler flags   : %s\n",COMPILER_FLAGS);
 #if (MULTITHREAD>1)

--- a/coremark.h
+++ b/coremark.h
@@ -44,6 +44,11 @@ Original Author: Shay Gal-on
 #define ee_printf printf
 #endif
 
+/* for printf, should be defined by inttypes.h */
+#ifndef PRIu32
+#define PRIu32 "lu"
+#endif
+
 /* Actual benchmark execution in iterate */
 void *iterate(void *pres);
 

--- a/linux/core_portme.h
+++ b/linux/core_portme.h
@@ -34,6 +34,16 @@ Original Author: Shay Gal-on
 #ifndef HAS_TIME_H
 #define HAS_TIME_H 1
 #endif
+/* Configuration : HAS_INTTYPES_H
+	Define to 1 if platform has the inittype.h header file,
+	and implementation of functions thereof.
+*/
+#ifndef HAS_INITTYPES_H
+#define HAS_INITTYPES_H 1
+#endif
+#if HAS_INITTYPES_H
+#include <inttypes.h>
+#endif
 /* Configuration: USE_CLOCK
 	Define to 1 if platform has the time.h header file,
 	and implementation of functions thereof.

--- a/linux64/core_portme.h
+++ b/linux64/core_portme.h
@@ -37,6 +37,16 @@ Original Author: Shay Gal-on
 #ifndef HAS_TIME_H
 #define HAS_TIME_H 1
 #endif
+/* Configuration : HAS_INTTYPES_H
+	Define to 1 if platform has the inittype.h header file,
+	and implementation of functions thereof.
+*/
+#ifndef HAS_INITTYPES_H
+#define HAS_INITTYPES_H 1
+#endif
+#if HAS_INITTYPES_H
+#include <inttypes.h>
+#endif
 /* Configuration: USE_CLOCK
 	Define to 1 if platform has the time.h header file,
 	and implementation of functions thereof.


### PR DESCRIPTION
For ports that do not include inttypes.h, default PRIu32 to
the current use of lu.