### PR TITLE
Replace size_t with ee_size_t in barebones/ee_printf.c

### DIFF
--- a/barebones/ee_printf.c
+++ b/barebones/ee_printf.c
@@ -29,9 +29,9 @@ limitations under the License.
 
 static char *digits = "0123456789abcdefghijklmnopqrstuvwxyz";
 static char *upper_digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-static size_t strnlen(const char *s, size_t count);
+static ee_size_t strnlen(const char *s, ee_size_t count);
 
-static size_t strnlen(const char *s, size_t count)
+static ee_size_t strnlen(const char *s, ee_size_t count)
 {
   const char *sc;
   for (sc = s; *sc != '\0' && count--; ++sc);


### PR DESCRIPTION
Does not change functionality for barebones/ee_printf.c. However, if this file is used as a basis for other ports' printf implementation, compilation might fail, since size_t may not be defined.

This commit modifies size_t to ee_size_t, a type which the benchmark requires the user to implement, with equal semantics.