### PR TITLE
Update md5sums so `make check` will pass

### DIFF
--- a/coremark.md5
+++ b/coremark.md5
@@ -1,6 +1,6 @@
-f837f8c5c5c6c0f5ef33bb1badc5ebef  core_list_join.c
-3c7e2aeca881577ae02d628ad56a584a  core_main.c
-6fef286af62d28486aa6e6c61fb11841  core_matrix.c
-640f7d70fab3ce61da49d0f9eef04f7f  core_state.c
-85a5a29a1c55be49787bc1e1e7082f80  core_util.c
-9233fff3d437a831187153be4da64d23  coremark.h
+8d082dc4a9676c02731a8cf209339072  core_list_join.c
+c984863b84b59185d8b5fb81c1ca7535  core_main.c
+5fa21a0f7c3964167c9691db531ca652  core_matrix.c
+edcfc7a0b146a50028014f06e6826aa3  core_state.c
+45540ba2145adea1ec7ea2c72a1fbbcb  core_util.c
+8ca974c013b380dc7f0d6d1afb76eb2d  coremark.h


### PR DESCRIPTION
It seems that the source files were reformatted a few months ago, but the md5sums file was not updated to match. As a result, `make check` is failing.