### PR TITLE
Stack overflow in ee_printf with DEBUG_CORE=1

### DIFF
--- a/barebones/ee_printf.c
+++ b/barebones/ee_printf.c
@@ -681,7 +681,7 @@ uart_send_char(char c)
 int
 ee_printf(const char *fmt, ...)
 {
-    char    buf[256], *p;
+    char    buf[1024], *p;
     va_list args;
     int     n = 0;
 


### PR DESCRIPTION
The statement

        ee_printf("State Input: %s\n", start);

from `core_main.c (193)` overflows the 256 byte `buf` array in
`ee_printf`.