### PR TITLE
Correct type of ee_ptr_int

### DIFF
--- a/linux64/core_portme.h
+++ b/linux64/core_portme.h
@@ -108,7 +108,7 @@ typedef signed int         ee_s32;
 typedef double             ee_f32;
 typedef unsigned char      ee_u8;
 typedef unsigned int       ee_u32;
-typedef unsigned long long ee_ptr_int;
+typedef unsigned long      ee_ptr_int;
 typedef size_t             ee_size_t;
 /* align an offset to point to a 32b value */
 #define align_mem(x) (void *)(4 + (((ee_ptr_int)(x)-1) & ~3))


### PR DESCRIPTION
Running core mark on 32bit Linux leads to and error:
"Please define ee_ptr_int to a type that holds a pointer!"

unsigned long long has 64bit both with 32bit and 64bit GCC.
unsigned long has 32bit length with 32bit GCC and 64big with
64bit GCC.

The correct integer type to represent void * with GCC is thus
unsigned long.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>