### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Many thanks to all of the individuals who helped with the development or testing
 * Shumpei Kawasaki, RENESAS
 
 # Legal
-Please refer to LICENSE.md in this reposity for a description of your rights to use this code.
+Please refer to LICENSE.md in this repository for a description of your rights to use this code.
 
 # Copyright
 Copyright © 2009 EEMBC All rights reserved. 

--- a/barebones/core_portme.c
+++ b/barebones/core_portme.c
@@ -95,7 +95,7 @@ stop_time(void)
 
         Actual value returned may be cpu cycles, milliseconds or any other
    value, as long as it can be converted to seconds by <time_in_secs>. This
-   methodology is taken to accomodate any hardware or simulated platform. The
+   methodology is taken to accommodate any hardware or simulated platform. The
    sample implementation returns millisecs by default, and the resolution is
    controlled by <TIMER_RES_DIVIDER>
 */
@@ -109,7 +109,7 @@ get_time(void)
 /* Function : time_in_secs
         Convert the value returned by get_time to seconds.
 
-        The <secs_ret> type is used to accomodate systems with no support for
+        The <secs_ret> type is used to accommodate systems with no support for
    floating point. Default implementation implemented by the EE_TICKS_PER_SEC
    macro above.
 */

--- a/barebones/core_portme.h
+++ b/barebones/core_portme.h
@@ -181,7 +181,7 @@ typedef ee_u32 CORE_TICKS;
 #endif
 
 /* Variable : default_num_contexts
-        Not used for this simple port, must cintain the value 1.
+        Not used for this simple port, must contain the value 1.
 */
 extern ee_u32 default_num_contexts;
 

--- a/core_list_join.c
+++ b/core_list_join.c
@@ -31,7 +31,7 @@ library.
 
         Instead, the memory block being passed in is used to create a list,
         and the benchmark takes care not to add more items then can be
-        accomodated by the memory block. The porting layer will make sure
+        accommodated by the memory block. The porting layer will make sure
         that we have a valid memory block.
 
         All operations are done in place, without using any extra memory.
@@ -253,7 +253,7 @@ core_list_init(ee_u32 blksize, list_head *memblock, ee_s16 seed)
     /* calculated pointers for the list */
     ee_u32 per_item = 16 + sizeof(struct list_data_s);
     ee_u32 size     = (blksize / per_item)
-                  - 2; /* to accomodate systems with 64b pointers, and make sure
+                  - 2; /* to accommodate systems with 64b pointers, and make sure
                           same code is executed, set max list elements */
     list_head *memblock_end  = memblock + size;
     list_data *datablock     = (list_data *)(memblock_end);

--- a/core_main.c
+++ b/core_main.c
@@ -146,7 +146,7 @@ main(int argc, char *argv[])
     /* put in some default values based on one seed only for easy testing */
     if ((results[0].seed1 == 0) && (results[0].seed2 == 0)
         && (results[0].seed3 == 0))
-    { /* perfromance run */
+    { /* performance run */
         results[0].seed1 = 0;
         results[0].seed2 = 0;
         results[0].seed3 = 0x66;

--- a/core_state.c
+++ b/core_state.c
@@ -206,7 +206,7 @@ ee_isdigit(ee_u8 c)
         Actual state machine.
 
         The state machine will continue scanning until either:
-        1 - an invalid input is detcted.
+        1 - an invalid input is detected.
         2 - a valid number has been detected.
 
         The input pointer is updated to point to the end of the token, and the

--- a/posix/core_portme.c
+++ b/posix/core_portme.c
@@ -171,7 +171,7 @@ stop_time(void)
 
         Actual value returned may be cpu cycles, milliseconds or any other
    value, as long as it can be converted to seconds by <time_in_secs>. This
-   methodology is taken to accomodate any hardware or simulated platform. The
+   methodology is taken to accommodate any hardware or simulated platform. The
    sample implementation returns millisecs by default, and the resolution is
    controlled by <TIMER_RES_DIVIDER>
 */
@@ -185,7 +185,7 @@ get_time(void)
 /* Function: time_in_secs
         Convert the value returned by get_time to seconds.
 
-        The <secs_ret> type is used to accomodate systems with no support for
+        The <secs_ret> type is used to accommodate systems with no support for
    floating point. Default implementation implemented by the EE_TICKS_PER_SEC
    macro above.
 */

--- a/simple/core_portme.c
+++ b/simple/core_portme.c
@@ -93,7 +93,7 @@ stop_time(void)
 
         Actual value returned may be cpu cycles, milliseconds or any other
    value, as long as it can be converted to seconds by <time_in_secs>. This
-   methodology is taken to accomodate any hardware or simulated platform. The
+   methodology is taken to accommodate any hardware or simulated platform. The
    sample implementation returns millisecs by default, and the resolution is
    controlled by <TIMER_RES_DIVIDER>
 */
@@ -107,7 +107,7 @@ get_time(void)
 /* Function : time_in_secs
         Convert the value returned by get_time to seconds.
 
-        The <secs_ret> type is used to accomodate systems with no support for
+        The <secs_ret> type is used to accommodate systems with no support for
    floating point. Default implementation implemented by the EE_TICKS_PER_SEC
    macro above.
 */

--- a/simple/core_portme.h
+++ b/simple/core_portme.h
@@ -181,7 +181,7 @@ typedef size_t         ee_size_t;
 #endif
 
 /* Variable : default_num_contexts
-        Not used for this simple port, must cintain the value 1.
+        Not used for this simple port, must contain the value 1.
 */
 extern ee_u32 default_num_contexts;
 


### PR DESCRIPTION
There are small typos in:
- README.md
- barebones/core_portme.c
- barebones/core_portme.h
- core_list_join.c
- core_main.c
- core_state.c
- posix/core_portme.c
- simple/core_portme.c
- simple/core_portme.h

Fixes:
- Should read `accommodate` rather than `accomodate`.
- Should read `contain` rather than `cintain`.
- Should read `repository` rather than `reposity`.
- Should read `performance` rather than `perfromance`.
- Should read `detected` rather than `detcted`.
- Should read `accommodated` rather than `accomodated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md