### PR TITLE
Improve Clang version reporting

### DIFF
--- a/posix/core_portme.h
+++ b/posix/core_portme.h
@@ -80,7 +80,9 @@ typedef clock_t CORE_TICKS;
         Initialize these strings per platform
 */
 #ifndef COMPILER_VERSION
-#ifdef __GNUC__
+#if defined(__clang__)
+#define COMPILER_VERSION __VERSION__
+#elif defined(__GNUC__)
 #define COMPILER_VERSION "GCC"__VERSION__
 #else
 #define COMPILER_VERSION "Please put compiler version here (e.g. gcc 4.1)"


### PR DESCRIPTION
Clang #defines __GNUC__ for compatibility, which results in a reported
compiler version like "GCCFreeBSD Clang 12.0.0 ..."

Add a case for __clang__ before __GNUC__ and just report __VERSION__,
which includes the compiler name and version number already (and
perhaps additional information).

Example from my laptop:
Compiler version : FreeBSD Clang 12.0.0 (git@github.com:llvm/llvm-project.git llvmorg-12.0.0-0-gd28af7c654d8)