### PR TITLE
Fix issues with SEPARATE_COMPILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ load: $(OUTFILE)
 
 .PHONY: clean
 clean:
-	rm -f $(OUTFILE) $(OPATH)*.log *.info $(OPATH)index.html $(PORT_CLEAN)
+	rm -f $(OUTFILE) $(OBJS) $(OPATH)*.log *.info $(OPATH)index.html $(PORT_CLEAN)
 
 .PHONY: force_rebuild
 force_rebuild:

--- a/posix/core_portme.mak
+++ b/posix/core_portme.mak
@@ -84,7 +84,10 @@ PORT_CLEAN = *$(OEXT)
 
 $(OPATH)%$(OEXT) : %.c
 	$(CC) $(CFLAGS) $(XCFLAGS) $(COUT) $< $(OBJOUT) $@
-	
+
+$(OPATH)$(PORT_DIR)/%$(OEXT) : posix/%.c
+	$(CC) $(CFLAGS) $(XCFLAGS) $(COUT) $< $(OBJOUT) $@
+
 endif
 
 # Target: port_prebuild


### PR DESCRIPTION
Firstly, clean does not actually clean OBJS, only the executable, so is mostly useless for SEPARATE_COMPILE.

Secondly, trying to build with PORT_DIR=freebsd SEPARATE_COMPILE=1 fails as it tries to build freebsd/core_portme.o from freebsd/core_portme.c. Arguably we should be building posix/core_portme.o, but that is awkward to implement due to part of the logic existing in the root Makefile as we'd need to make it know to mkdir posix/ instead of freebsd/ (for the OPATH != ./ case). Instead we can just add another rule in the posix core_portme.mak that maps PORT_DIR to posix. (This one was my fault, did not test SEPARATE_COMPILE when I submitted the patch that made the combined posix port...)
