### PR TITLE
fixe #42 adding void cast and explicit initialisation

### DIFF
--- a/barebones/core_portme.c
+++ b/barebones/core_portme.c
@@ -131,6 +131,10 @@ portable_init(core_portable *p, int *argc, char *argv[])
 {
 #error \
     "Call board initialization routines in portable init (if needed), in particular initialize UART!\n"
+
+    (void)argc; // prevent unused warning
+    (void)argv; // prevent unused warning
+
     if (sizeof(ee_ptr_int) != sizeof(ee_u8 *))
     {
         ee_printf(

--- a/core_list_join.c
+++ b/core_list_join.c
@@ -164,7 +164,7 @@ core_bench_list(core_results *res, ee_s16 finder_idx)
     ee_s16     find_num = res->seed3;
     list_head *this_find;
     list_head *finder, *remover;
-    list_data  info;
+    list_data  info = {0};
     ee_s16     i;
 
     info.idx = finder_idx;

--- a/posix/core_portme.c
+++ b/posix/core_portme.c
@@ -215,6 +215,10 @@ portable_init(core_portable *p, int *argc, char *argv[])
         ee_printf("Arg[%d]=%s\n", i, argv[i]);
     }
 #endif
+
+    (void)argc; // prevent unused warning
+    (void)argv; // prevent unused warning
+    
     if (sizeof(ee_ptr_int) != sizeof(ee_u8 *))
     {
         ee_printf(

--- a/simple/core_portme.c
+++ b/simple/core_portme.c
@@ -127,6 +127,10 @@ ee_u32 default_num_contexts = 1;
 void
 portable_init(core_portable *p, int *argc, char *argv[])
 {
+
+    (void)argc; // prevent unused warning
+    (void)argv; // prevent unused warning
+
     if (sizeof(ee_ptr_int) != sizeof(ee_u8 *))
     {
         ee_printf(


### PR DESCRIPTION
This is achieved by adding void-casts and explicit initialisation.

- For `core_portme.c` in function `portable_init` adding this castes fakes the using of `argc` and `argv`.
- Adding ` = {0}` in `core_list_join.c` ensures the proper initialisation of `info`.