### PR TITLE
zephyr: glueing to the zephyr build system added

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: coremark
+build:
+    cmake-ext: True
+    kconfig-ext: True


### PR DESCRIPTION
To add CoreMark repository as a module to [the zephyr project](https://github.com/zephyrproject-rtos/zephyr) a simple glueing to the zephyr build system is required.

Coremark configuration, porting layer and all necessary files will be a part of the zephyr repository.

This PR is also needed to avoid keeping own fork for the CoreMark repository.

This PR provides very minimum required change that allows using CoreMark within zephyr infrastructure as an external module.

Zephyr is a core part of NRF Connect SDK, provided by Nordic Semiconductor.
Links:
* https://github.com/nrfconnect/sdk-zephyr
* https://github.com/zephyrproject-rtos/zephyr

Signed-off-by: Volodymyr Bondarchuk <volodymyr.bondarchuk@nordicsemi.no>