### PR TITLE
Print total_time as unsigned long long

### DIFF
--- a/core_main.c
+++ b/core_main.c
@@ -356,7 +356,7 @@ for (i = 0; i < MULTITHREAD; i++)
     total_errors += check_data_types();
     /* and report results */
     ee_printf("CoreMark Size    : %lu\n", (long unsigned)results[0].size);
-    ee_printf("Total ticks      : %lu\n", (long unsigned)total_time);
+    ee_printf("Total ticks      : %llu\n", (long long unsigned)total_time);
 #if HAS_FLOAT
     ee_printf("Total time (secs): %f\n", time_in_secs(total_time));
     if (time_in_secs(total_time) > 0)


### PR DESCRIPTION
CoreMark requires calculations to be performed for at least 10 seconds. So for processors with frequency > 429.5 MHz the total time in processor's ticks will exceed the size of 32-bit variable.

Not for all platforms sizeof(long unsigned) = 8 bytes. The C language standard guarantees the minimum size for types. For unsigned long the minimum size is 4 bytes so the output of the total_time may be incorrect.

Type long long unsigned should be used for which 8 byte size is guaranteed by C language standard.