### PR TITLE
Add support to add attributes to static_memblk via macro

### DIFF
--- a/core_main.c
+++ b/core_main.c
@@ -82,7 +82,7 @@ ee_s32 get_seed_32(int i);
 #endif
 
 #if (MEM_METHOD == MEM_STATIC)
-ee_u8 static_memblk[TOTAL_DATA_SIZE];
+MEM_STATIC_ATTR ee_u8 static_memblk[TOTAL_DATA_SIZE];
 #endif
 char *mem_name[3] = { "Static", "Heap", "Stack" };
 /* Function: main


### PR DESCRIPTION
This allows for putting it into different linker script sections to facilitate testing different memory configurations. For example MEM_STATIC_ATTR='__attribute__((section("sdram")))' tells the linker to put the data memory of coremark into the section named sdram.

TODO: makefile, docs

What do you think?