### PR TITLE
Fix error collision

### DIFF
--- a/core_main.c
+++ b/core_main.c
@@ -315,7 +315,7 @@ for (i = 0; i < MULTITHREAD; i++)
             ee_printf("2K validation run parameters for coremark.\n");
             break;
         default:
-            total_errors = -1;
+            total_errors++;
             break;
     }
     if (known_id >= 0)
@@ -426,7 +426,7 @@ for (i = 0; i < MULTITHREAD; i++)
     }
     if (total_errors > 0)
         ee_printf("Errors detected\n");
-    if (total_errors < 0)
+    if (known_id < 0)
         ee_printf(
             "Cannot validate operation for these seed values, please compare "
             "with results on a known platform.\n");


### PR DESCRIPTION
There are four types of errors:

- Unknown seed,
- CRC mismatch,
- Invalid types,
- Execution time < 10s.

All of these errors are handled by the 'total_errors' variable. However, handling of the 'unknown seed' error differs from other types: it sets 'total_errors' to -1, while other types of errors increment this variable.

This behavior leads to situations where one error overrides another. For example, if you compile the program incorrectly and get an unknown seed, and then run the program for less than 10 seconds, you will get total_errors = 0 (because one error sets it to -1, while another increments it to 0). See #4.

As a result, you'll receive "Correct operation validated" when you shouldn't.