### PR TITLE
Add option to measure last iterration

### DIFF
--- a/core_main.c
+++ b/core_main.c
@@ -370,10 +370,11 @@ for (i = 0; i < MULTITHREAD; i++)
                   default_num_contexts * results[0].iterations
                       / time_in_secs(total_time));
 #endif
-    if (time_in_secs(total_time) < 10)
+    if (time_in_secs(total_time) < CORE_MIN_RUNTIME)
     {
         ee_printf(
-            "ERROR! Must execute for at least 10 secs for a valid result!\n");
+            "ERROR! Must execute for at least %d secs for a valid result!\n",
+            CORE_MIN_RUNTIME);
         total_errors++;
     }
 

--- a/coremark.h
+++ b/coremark.h
@@ -44,6 +44,10 @@ Original Author: Shay Gal-on
 #define ee_printf printf
 #endif
 
+#ifndef CORE_MIN_RUNTIME
+#define CORE_MIN_RUNTIME 10
+#endif
+
 /* Actual benchmark execution in iterate */
 void *iterate(void *pres);
 

--- a/coremark.h
+++ b/coremark.h
@@ -185,3 +185,8 @@ ee_u32 core_init_matrix(ee_u32      blksize,
                         ee_s32      seed,
                         mat_params *p);
 ee_u16 core_bench_matrix(mat_params *p, ee_s16 seed, ee_u16 crc);
+
+/* Single iteration time measurement */
+#ifndef MEASURE_ONE_ITER
+#define MEASURE_ONE_ITER 0
+#endif


### PR DESCRIPTION
This PR introduces:
* `MEASURE_ONE_ITER` - if defined, only time of the last iteration will be displayed,
* `CORE_MIN_RUNTIME` - defines minimum length of the runtime (in seconds).