### PR TITLE
Update typedef ee_f32 from double to float.

### DIFF
--- a/barebones/core_portme.h
+++ b/barebones/core_portme.h
@@ -87,7 +87,7 @@ Original Author: Shay Gal-on
 typedef signed short   ee_s16;
 typedef unsigned short ee_u16;
 typedef signed int     ee_s32;
-typedef double         ee_f32;
+typedef float          ee_f32;
 typedef unsigned char  ee_u8;
 typedef unsigned int   ee_u32;
 typedef ee_u32         ee_ptr_int;

--- a/posix/core_portme.h
+++ b/posix/core_portme.h
@@ -112,7 +112,7 @@ typedef clock_t CORE_TICKS;
 typedef signed short   ee_s16;
 typedef unsigned short ee_u16;
 typedef signed int     ee_s32;
-typedef double         ee_f32;
+typedef float          ee_f32;
 typedef unsigned char  ee_u8;
 typedef unsigned int   ee_u32;
 typedef uintptr_t      ee_ptr_int;

--- a/simple/core_portme.h
+++ b/simple/core_portme.h
@@ -94,7 +94,7 @@ typedef clock_t CORE_TICKS;
 typedef signed short   ee_s16;
 typedef unsigned short ee_u16;
 typedef signed int     ee_s32;
-typedef double         ee_f32;
+typedef float          ee_f32;
 typedef unsigned char  ee_u8;
 typedef unsigned int   ee_u32;
 typedef ee_u32         ee_ptr_int;


### PR DESCRIPTION
This patch addresses https://github.com/eembc/coremark/issues/50, where ee_f32 was previously mapped to double.
Because double is 64-bit in most modern processor architecture, it is confusing and float data type is more suitable.
 
3 files are modified:
- barebones/core_portme.h
- posix/core_portme.h
- simple/core_portme.h

The change does not affect CoreMark result because CoreMark does not have floating-point workload.
Note 1: In coremark.h, ee_f32 is used in the following code:
```
/*matrix benchmark related stuff */
#define MATDAT_INT 1
#if MATDAT_INT
typedef ee_s16 MATDAT;
typedef ee_s32 MATRES;
#else
typedef ee_f16 MATDAT;
typedef ee_f32 MATRES;
#endif
```
Since the C macro MATDAT_INT is fixed to 1, MATRES is always mapped to ee_s32.
As a result ee_f32 was not really used.

Note 2: The change is in core_portme.h, a user modifiable file.
