### PR TITLE
Use PRIu32 format specifier when printing time_in_secs

### DIFF
--- a/core_main.c
+++ b/core_main.c
@@ -364,7 +364,7 @@ for (i = 0; i < MULTITHREAD; i++)
                   default_num_contexts * results[0].iterations
                       / time_in_secs(total_time));
 #else
-    ee_printf("Total time (secs): %d\n", time_in_secs(total_time));
+    ee_printf("Total time (secs): %"PRIu32"\n", time_in_secs(total_time));
     if (time_in_secs(total_time) > 0)
         ee_printf("Iterations/Sec   : %"PRIu32"\n",
                   default_num_contexts * results[0].iterations

--- a/core_main.c
+++ b/core_main.c
@@ -366,7 +366,7 @@ for (i = 0; i < MULTITHREAD; i++)
 #else
     ee_printf("Total time (secs): %d\n", time_in_secs(total_time));
     if (time_in_secs(total_time) > 0)
-        ee_printf("Iterations/Sec   : %d\n",
+        ee_printf("Iterations/Sec   : %"PRIu32"\n",
                   default_num_contexts * results[0].iterations
                       / time_in_secs(total_time));
 #endif

--- a/coremark.h
+++ b/coremark.h
@@ -41,6 +41,8 @@ Original Author: Shay Gal-on
 #include <stdio.h>
 #endif
 #if HAS_PRINTF
+/* Adding inttypes.h (C99) to support PRIu32 in printf */
+#include <inttypes.h>
 #define ee_printf printf
 #endif
 


### PR DESCRIPTION
This patch addresses https://github.com/eembc/coremark/issues/35, where a printf statement for time_in_secs() (ee_u32) used the %d format specifier for int. The issue arise when using a 16-bit architecture where %d (int) does not match the size of ee_u32.

2 files are modified:
- core_main.c
- coremark.h (adding inttypes.h)

The change does not affect CoreMark result as it only impact the code for execution time reporting (after the workload is completed).